### PR TITLE
Introduce the new jsx transform

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -8,6 +8,13 @@ rules:
   '@typescript-eslint/no-empty-function': off
 overrides:
   - files:
+      - '*.tsx'
+    plugins:
+      - react
+    rules:
+      react/jsx-uses-react: off
+      react/react-in-jsx-scope: off
+  - files:
       - jest.config.js
     env:
       node: true

--- a/__tests__/UseLoginStateManager.test.tsx
+++ b/__tests__/UseLoginStateManager.test.tsx
@@ -1,12 +1,12 @@
 import { liff as liffMock } from '@line/liff';
 import { fireEvent, render, waitFor } from '@testing-library/react';
-import React from 'react';
+import { FC } from 'react';
 
 import { useLoginStateManager } from '#/use-login-state-manager';
 
 jest.mock('@line/liff');
 
-const TestComponent: React.FC<{ liff?: any }> = ({ liff }) => {
+const TestComponent: FC<{ liff?: any }> = ({ liff }) => {
   const [isLoggedIn, customLiff] = useLoginStateManager(liff);
 
   return (

--- a/__tests__/index.test.tsx
+++ b/__tests__/index.test.tsx
@@ -1,13 +1,13 @@
 import { liff } from '@line/liff';
 import { render, waitFor } from '@testing-library/react';
-import React from 'react';
+import { FC } from 'react';
 
 import { LiffProvider, useLiff } from '#/index';
 import { Liff } from '#/types';
 
 jest.mock('@line/liff');
 
-const TestComponent: React.FC = () => {
+const TestComponent: FC = () => {
   const { error, liff, ready } = useLiff();
 
   return (

--- a/__tests__/tsconfig.json
+++ b/__tests__/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "jsx": "react-jsxdev",
     "rootDir": "../",
     "noEmit": true,
     "baseUrl": "../",

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   collectCoverageFrom: ['<rootDir>/src/**/*.ts{,x}'],
   globals: {
     'ts-jest': {
-      tsConfig: '__tests__/tsconfig.json',
+      tsconfig: '__tests__/tsconfig.json',
     },
   },
   moduleNameMapper: {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react-dom": "^17.0.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.1.0",
-    "typescript": "^4.0.2"
+    "typescript": "^4.1.2"
   },
   "peerDependencies": {
     "prop-types": "*",

--- a/src/Context.tsx
+++ b/src/Context.tsx
@@ -1,5 +1,5 @@
 import * as PropTypes from 'prop-types';
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import { Consumer, Context, createContext, FC, useContext, useEffect, useState } from 'react';
 
 import { liffStub as stub } from './liff-stub';
 import { LiffCore, LiffError } from './types';
@@ -18,8 +18,8 @@ interface LiffContext<T> {
   ready: boolean;
 }
 type CreateLiffContext = <T extends LiffCore>() => {
-  LiffConsumer: React.Consumer<LiffContext<T>>;
-  LiffProvider: React.FC<LiffProviderProps<T>>;
+  LiffConsumer: Consumer<LiffContext<T>>;
+  LiffProvider: FC<LiffProviderProps<T>>;
   useLiff: () => LiffContext<T>;
 };
 
@@ -46,12 +46,8 @@ const LiffProviderPropTypes = {
   stubEnabled: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
 };
 
-const createLiffProvider = <T extends LiffCore>(context: React.Context<LiffContext<T>>) => {
-  const LiffProvider: React.FC<LiffProviderProps<T>> = ({
-    children,
-    liffId,
-    stubEnabled = false,
-  }) => {
+const createLiffProvider = <T extends LiffCore>(context: Context<LiffContext<T>>) => {
+  const LiffProvider: FC<LiffProviderProps<T>> = ({ children, liffId, stubEnabled = false }) => {
     const [error, setError] = useState<LiffError>();
     const [originalLiff, setLiff] = useState<T>(stub as T);
     const [ready, setReady] = useState(false);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     ],
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
-    "jsx": "react",                           /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "jsx": "react-jsx",                       /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     "declaration": true,                      /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -5154,7 +5154,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.0.2:
+typescript@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
   integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==


### PR DESCRIPTION
https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html

* Update package.json to upgrade required version of typescript
* Update tsconfig.json to use new jsx transform
* Update eslintrc to disable the rules that have not needed.
* Remove `import React` from src/, __tests__/