### PR TITLE
Drop supporting `@line/liff` version under 2.19.0

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,26 +43,6 @@ jobs:
         react:
           - react-version: 18
         liff-sdk:
-          - sdk-version: '2.9'
-            continue-on-error: false
-          - sdk-version: '2.10'
-            continue-on-error: false
-          - sdk-version: '2.11'
-            continue-on-error: false
-          - sdk-version: '2.12'
-            continue-on-error: false
-          - sdk-version: '2.13'
-            continue-on-error: false
-          - sdk-version: '2.14'
-            continue-on-error: false
-          - sdk-version: '2.15'
-            continue-on-error: false
-          - sdk-version: '2.16'
-            continue-on-error: false
-          - sdk-version: '2.17'
-            continue-on-error: false
-          - sdk-version: '2.18'
-            continue-on-error: false
           - sdk-version: '2.19'
             continue-on-error: false
           - sdk-version: '2.20'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 - [#452](https://github.com/epaew/react-liff/pull/452)
   - Dropped supporting `react@16.x`, `react@17.x`.
+- [#453](https://github.com/epaew/react-liff/pull/453)
+  - Dropped supporting `@line/liff` version 2.19.0 or earlier.
 
 ## Others
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A react context provider for LIFF (LINE Front-end Framework)
 
 - [React](https://reactjs.org/) v16.14 or later
   - React Native is not supported.
-- [LIFF SDK](https://developers.line.biz/en/docs/liff/release-notes/#liff-version-and-release-date) version >=2.9.0
+- [LIFF SDK](https://developers.line.biz/en/docs/liff/release-notes/#liff-version-and-release-date) version >=2.19.1
 
 ## Getting started
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@epaew/eslint-config": "https://github.com/epaew/eslint-config.git#master",
     "@epaew/prettier-config": "https://github.com/epaew/prettier-config.git#master",
-    "@line/liff": ">=2.9.0 <2.21.0",
+    "@line/liff": ">=2.19.1 <2.21.0",
     "@testing-library/react": "^13.3.0",
     "@types/jest": "^28.1.1",
     "@types/prop-types": "^15.7.3",
@@ -60,6 +60,6 @@
     "react": ">=18.0.0 <19.0.0"
   },
   "optionalDependencies": {
-    "@line/liff": ">=2.9.0 <2.21.0"
+    "@line/liff": ">=2.19.1 <2.21.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -293,7 +293,6 @@
 
 "@epaew/eslint-config@https://github.com/epaew/eslint-config.git#master":
   version "0.1.0"
-  uid cc03cff820fa6bcba2957ac9556f463790a6b89e
   resolved "https://github.com/epaew/eslint-config.git#cc03cff820fa6bcba2957ac9556f463790a6b89e"
   dependencies:
     "@typescript-eslint/eslint-plugin" "^5.27.1"
@@ -1028,7 +1027,7 @@
     file-type "^15.0.0"
     form-data "^3.0.0"
 
-"@line/liff@>=2.9.0 <2.21.0":
+"@line/liff@>=2.19.1 <2.21.0":
   version "2.20.2"
   resolved "https://registry.yarnpkg.com/@line/liff/-/liff-2.20.2.tgz#831be41a44c9ae10e96a38ad855524e897d38bcf"
   integrity sha512-af2EOeuUpoIxsRV4rqSZrWTf9m8UrTiDQg/sTefcb/kqdgSpP54FzB6aMeUbL4QNmnA1zVCM4oQ3F2an93c2Wg==


### PR DESCRIPTION
Related issue: #447 